### PR TITLE
Add handlePressKeyboard() for scrolling layout with key

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ HTML setup:
 
 ## Options
 
-| Attribute | Type        | Default     | Description                                                     |
+| Attribute              | Type        | Default     | Description                                                     |
 |------------------------|-------------|-------------|-----------------------------------------------------------------|
 | `wrapper`              | DOM element | `undefined` | Required. Wrapper element.                                      |
 | `smoothScroll`         | boolean     | `true`      | Enable smooth scroll                                            |
 | `verticalBreakpoint`   | number      | `1024`      | Switch to vertical layout mode when `window.innerWidth <= 1024` |
 | `smoothVerticalScroll` | boolean     | `true`      | Enable smooth scroll for vertical layout mode                   |
-| `keyScrollDistance` | number      | `200`       | Distance to scroll on each key press (px)                       |
-| `keyScroll` | boolean     | `true`      | Enable navigate by a arrow key                                  |
+| `keyScrollDistance`    | number      | `200`       | Distance to scroll on each key press (px)                       |
+| `keyScroll`            | boolean     | `true`      | Enable navigate by a arrow key                                  |
 
 ```js
 // init with options

--- a/README.md
+++ b/README.md
@@ -85,12 +85,14 @@ HTML setup:
 
 ## Options
 
-| Attribute | Type | Default | Description |
-|------------------------|--|-------------------|-----------------------------------------------|
-| `wrapper`              | DOM element | `undefined` | Required. Wrapper element. |
-| `smoothScroll`         | boolean | `true`           | Enable smooth scroll |
-| `verticalBreakpoint`   | number | `1024`          | Switch to vertical layout mode when `window.innerWidth <= 1024` |
-| `smoothVerticalScroll` | boolean | `true`            | Enable smooth scroll for vertical layout mode |
+| Attribute | Type        | Default     | Description                                                     |
+|------------------------|-------------|-------------|-----------------------------------------------------------------|
+| `wrapper`              | DOM element | `undefined` | Required. Wrapper element.                                      |
+| `smoothScroll`         | boolean     | `true`      | Enable smooth scroll                                            |
+| `verticalBreakpoint`   | number      | `1024`      | Switch to vertical layout mode when `window.innerWidth <= 1024` |
+| `smoothVerticalScroll` | boolean     | `true`      | Enable smooth scroll for vertical layout mode                   |
+| `keyScrollDistance` | number      | `200`       | Distance to scroll on each key press (px)                       |
+| `keyScroll` | boolean     | `true`      | Enable navigate by a arrow key                                  |
 
 ```js
 // init with options

--- a/src/_index.js
+++ b/src/_index.js
@@ -51,21 +51,6 @@ class CuaJsClass{
         this.style = new Styling(this)
 
         /** SCROLL **/
-        function handlePressKeyboard(wrapper, keyScrollDist){
-            window.addEventListener("keydown", e => {
-                // enter previous keyboard
-                if(e.key === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
-
-                // enter next keyboard
-                if(e.key === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
-
-                //scroll
-                CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});
-            })
-        }
-
-        handlePressKeyboard(this.wrapper, this.options.keyScrollDist);
-
         this.isSmoothScroll = this.options.smoothScroll && typeof Lenis !== 'undefined'
         if(this.isSmoothScroll){
             this.wrapper.classList.add(CLASSES.hasSmoothScroll)

--- a/src/_index.js
+++ b/src/_index.js
@@ -51,6 +51,21 @@ class CuaJsClass{
         this.style = new Styling(this)
 
         /** SCROLL **/
+        function handlePressKeyboard(wrapper, keyScrollDist){
+            window.addEventListener("keydown", e => {
+                // enter previous keyboard
+                if(e.key === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
+
+                // enter next keyboard
+                if(e.key === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
+
+                //scroll
+                CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});
+            })
+        }
+
+        handlePressKeyboard(this.wrapper, this.options.keyScrollDist);
+
         this.isSmoothScroll = this.options.smoothScroll && typeof Lenis !== 'undefined'
         if(this.isSmoothScroll){
             this.wrapper.classList.add(CLASSES.hasSmoothScroll)

--- a/src/configs.js
+++ b/src/configs.js
@@ -28,8 +28,8 @@ export const DEFAULTS = {
 
     // smooth scroll
     smoothScroll: true,
-    keyScrollDistance: 200, // px
-    keyScroll: true, // enable navigate by a scroll key
+    keyScrollDistance: 200, // distance to scroll on each key press (px)
+    keyScroll: true, // enable to navigate by a arrow key
 
     // responsive
     verticalBreakpoint: 1024, // (int)number for CSS breakpoint

--- a/src/configs.js
+++ b/src/configs.js
@@ -28,7 +28,7 @@ export const DEFAULTS = {
 
     // smooth scroll
     smoothScroll: true,
-    keyScrollDist: 200, // px
+    keyScrollDistance: 200, // px
     keyScroll: true,
 
     // responsive

--- a/src/configs.js
+++ b/src/configs.js
@@ -28,7 +28,8 @@ export const DEFAULTS = {
 
     // smooth scroll
     smoothScroll: true,
-    keyScrollDist: 500, // px
+    keyScrollDist: 200, // px
+    keyScroll: true,
 
     // responsive
     verticalBreakpoint: 1024, // (int)number for CSS breakpoint

--- a/src/configs.js
+++ b/src/configs.js
@@ -29,7 +29,7 @@ export const DEFAULTS = {
     // smooth scroll
     smoothScroll: true,
     keyScrollDistance: 200, // px
-    keyScroll: true,
+    keyScroll: true, // enable navigate by a scroll key
 
     // responsive
     verticalBreakpoint: 1024, // (int)number for CSS breakpoint

--- a/src/configs.js
+++ b/src/configs.js
@@ -28,6 +28,7 @@ export const DEFAULTS = {
 
     // smooth scroll
     smoothScroll: true,
+    keyScrollDist: 500, // px
 
     // responsive
     verticalBreakpoint: 1024, // (int)number for CSS breakpoint

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -39,17 +39,16 @@ export class LenisSmoothScroll{
 
         // scroll when keypress executed
         if(this.context.options.keyScroll){
-            const wrapper = element;
             const keyScrollDistance = this.context.options.keyScrollDistance;
             window.addEventListener("keydown", event => {
                 // enter previous keyboard
-                if(event.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDistance;
+                if(event.code === "ArrowLeft") element.scrollLeft -= keyScrollDistance;
 
                 // enter next keyboard
-                if(event.code === "ArrowRight") wrapper.scrollLeft += keyScrollDistance;
+                if(event.code === "ArrowRight") element.scrollLeft += keyScrollDistance;
 
                 //scroll
-                CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});
+                CuaJsData.lenis.instance.scrollTo(element.scrollLeft, {lock: true});
             })
         }
 

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -41,12 +41,12 @@ export class LenisSmoothScroll{
         if(this.context.options.keyScroll){
             const wrapper = element;
             const keyScrollDistance = this.context.options.keyScrollDistance;
-            window.addEventListener("keydown", e => {
+            window.addEventListener("keydown", event => {
                 // enter previous keyboard
-                if(e.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDistance;
+                if(event.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDistance;
 
                 // enter next keyboard
-                if(e.code === "ArrowRight") wrapper.scrollLeft += keyScrollDistance;
+                if(event.code === "ArrowRight") wrapper.scrollLeft += keyScrollDistance;
 
                 //scroll
                 CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -96,7 +96,6 @@ export class LenisSmoothScroll{
         // on vertically scroll
         lenis.on('scroll', event => handleOnScroll(event, this.context, 'vertical'));
 
-
         function raf(time){
             lenis.raf(time)
             requestAnimationFrame(raf);
@@ -174,4 +173,3 @@ function handleOnScroll(event, context, axis){
         activeIndex: getActiveSectionIndex(context, progress)
     });
 }
-

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -37,6 +37,22 @@ export class LenisSmoothScroll{
             }
         });
 
+        // scroll when keypress executed
+        function handlePressKeyboard(wrapper, keyScrollDist){
+            window.addEventListener("keydown", e => {
+                // enter previous keyboard
+                if(e.key === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
+
+                // enter next keyboard
+                if(e.key === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
+
+                //scroll
+                CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});
+            })
+        }
+
+        handlePressKeyboard(this.element, this.context.options.keyScrollDist);
+
         // init
         const lenis = new Lenis({
             ...this.lenisOptions,
@@ -79,6 +95,8 @@ export class LenisSmoothScroll{
 
         // on vertically scroll
         lenis.on('scroll', event => handleOnScroll(event, this.context, 'vertical'));
+
+
 
         function raf(time){
             lenis.raf(time)
@@ -157,3 +175,4 @@ function handleOnScroll(event, context, axis){
         activeIndex: getActiveSectionIndex(context, progress)
     });
 }
+

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -38,7 +38,9 @@ export class LenisSmoothScroll{
         });
 
         // scroll when keypress executed
-        function handlePressKeyboard(wrapper, keyScrollDist){
+        if(this.context.options.keyScroll){
+            const wrapper = element;
+            const keyScrollDist = this.context.options.keyScrollDist;
             window.addEventListener("keydown", e => {
                 // enter previous keyboard
                 if(e.key === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
@@ -50,8 +52,6 @@ export class LenisSmoothScroll{
                 CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});
             })
         }
-
-        handlePressKeyboard(this.element, this.context.options.keyScrollDist);
 
         // init
         const lenis = new Lenis({

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -97,7 +97,6 @@ export class LenisSmoothScroll{
         lenis.on('scroll', event => handleOnScroll(event, this.context, 'vertical'));
 
 
-
         function raf(time){
             lenis.raf(time)
             requestAnimationFrame(raf);

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -43,10 +43,10 @@ export class LenisSmoothScroll{
             const keyScrollDist = this.context.options.keyScrollDist;
             window.addEventListener("keydown", e => {
                 // enter previous keyboard
-                if(e.key === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
+                if(e.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
 
                 // enter next keyboard
-                if(e.key === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
+                if(e.code === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
 
                 //scroll
                 CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -40,13 +40,13 @@ export class LenisSmoothScroll{
         // scroll when keypress executed
         if(this.context.options.keyScroll){
             const wrapper = element;
-            const keyScrollDist = this.context.options.keyScrollDist;
+            const keyScrollDistance = this.context.options.keyScrollDistance;
             window.addEventListener("keydown", e => {
                 // enter previous keyboard
-                if(e.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDist;
+                if(e.code === "ArrowLeft") wrapper.scrollLeft -= keyScrollDistance;
 
                 // enter next keyboard
-                if(e.code === "ArrowRight") wrapper.scrollLeft += keyScrollDist;
+                if(e.code === "ArrowRight") wrapper.scrollLeft += keyScrollDistance;
 
                 //scroll
                 CuaJsData.lenis.instance.scrollTo(wrapper.scrollLeft, {lock: true});

--- a/src/lenis-smooth-scroll.js
+++ b/src/lenis-smooth-scroll.js
@@ -40,15 +40,16 @@ export class LenisSmoothScroll{
         // scroll when keypress executed
         if(this.context.options.keyScroll){
             const keyScrollDistance = this.context.options.keyScrollDistance;
+            let scrollOffset = element.scrollLeft;
             window.addEventListener("keydown", event => {
-                // enter previous keyboard
-                if(event.code === "ArrowLeft") element.scrollLeft -= keyScrollDistance;
+                // left/up arrow key => go backward
+                if(event.code === "ArrowLeft" || event.code === "ArrowUp") scrollOffset -= keyScrollDistance;
 
-                // enter next keyboard
-                if(event.code === "ArrowRight") element.scrollLeft += keyScrollDistance;
+                // right/down arrow key => go forward
+                if(event.code === "ArrowRight" || event.code === "ArrowDown") scrollOffset += keyScrollDistance;
 
-                //scroll
-                CuaJsData.lenis.instance.scrollTo(element.scrollLeft, {lock: true});
+                // smooth scroll
+                CuaJsData.lenis.instance.scrollTo(scrollOffset, {lock: false});
             })
         }
 


### PR DESCRIPTION
We have 3 options:
- e.key: Not mention to use in MDN docs.
- e.keyCode: **[deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#:~:text=Deprecated%3A%20This,at%20any%20time.)**.
- e.code: [MDN recommend to use](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#:~:text=Instead%2C%20you%20should%20use%20KeyboardEvent.code).

