### PR TITLE
fix(styling): make sure the wrapper always full height

### DIFF
--- a/src/styling.js
+++ b/src/styling.js
@@ -24,7 +24,9 @@ function setHorizontalModeCSS(context){
     setCSS(context.wrapper, {
         display: 'flex', /* force into one lines */
         overflow: 'auto', /* allow scrolling */
+        height: `100vh`, /* always full-height */
         minHeight: `100vh`, /* always full-height */
+        maxHeight: `100vh`, /* always full-height */
     });
 
     // sections
@@ -49,6 +51,8 @@ function setVerticalModeCSS(context){
     setCSS(context.wrapper, {
         display: '',
         overflow: '',
+        height: '',
+        maxHeight: '',
         minHeight: '',
     });
 


### PR DESCRIPTION
This pull request includes modifications to the CSS settings in the `src/styling.js` file to ensure consistent height properties for both horizontal and vertical modes.

Changes to horizontal mode CSS:

* [`src/styling.js`](diffhunk://#diff-ee3006c238461490dd3b1a55e2b50bcc53de397b3ffbf40b2da18d4ebbd4c7f2R27-R29): Added `height` and `maxHeight` properties to ensure the wrapper is always full-height in horizontal mode.

Changes to vertical mode CSS:

* [`src/styling.js`](diffhunk://#diff-ee3006c238461490dd3b1a55e2b50bcc53de397b3ffbf40b2da18d4ebbd4c7f2R54-R55): Added `height` and `maxHeight` properties to reset the height settings in vertical mode.